### PR TITLE
normalize family="R-Core"-->given="R-core"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Mixed Model ANOVA and Statistics for Education
 Version: 1.4.2.2
 Date: 2025-02-13
 Authors@R: c(person("Kristian Hovde", "Liland", role = c("aut","cre"), email="kristian.liland@nmbu.no"),
- person("Solve", "Sæbø¸", role=c("ctb")), person(given="R-core", role="ctb"))
+ person("Solve", "Sæbø¸", role="ctb"), person(given="R-core", role="ctb", email="R-core@R-project.org"))
 Maintainer: Kristian Hovde Liland <kristian.liland@nmbu.no>
 Encoding: UTF-8
 Description: The main functions perform mixed models analysis by least squares

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Mixed Model ANOVA and Statistics for Education
 Version: 1.4.2.2
 Date: 2025-02-13
 Authors@R: c(person("Kristian Hovde", "Liland", role = c("aut","cre"), email="kristian.liland@nmbu.no"),
- person("Solve", "Sæbø¸", role=c("ctb")), person(family="R-core", role="ctb"))
+ person("Solve", "Sæbø¸", role=c("ctb")), person(given="R-core", role="ctb"))
 Maintainer: Kristian Hovde Liland <kristian.liland@nmbu.no>
 Encoding: UTF-8
 Description: The main functions perform mixed models analysis by least squares

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Mixed Model ANOVA and Statistics for Education
 Version: 1.4.2.2
 Date: 2025-02-13
 Authors@R: c(person("Kristian Hovde", "Liland", role = c("aut","cre"), email="kristian.liland@nmbu.no"),
- person("Solve", "Sæbø¸", role=c("ctb")), person(family="R-Core", role="ctb"))
+ person("Solve", "Sæbø¸", role=c("ctb")), person(family="R-core", role="ctb"))
 Maintainer: Kristian Hovde Liland <kristian.liland@nmbu.no>
 Encoding: UTF-8
 Description: The main functions perform mixed models analysis by least squares


### PR DESCRIPTION
`R-core` is listed as a contributor on 9 packages, vs. 4 for `R-Core`. May as well normalize.

{mixlm} is also the only one to put it as `family`, not `given`, inside `person()`.

```r
tools::CRAN_authors_db() |>
  subset(grepl("(?i)r-core", paste(given, family)))
```